### PR TITLE
ham: Fix file context duplication

### DIFF
--- a/sepolicy/bootanim.te
+++ b/sepolicy/bootanim.te
@@ -1,3 +1,0 @@
-allow bootanim mpdecision:unix_stream_socket connectto;
-allow bootanim mpctl_socket:dir search;
-unix_socket_send(bootanim, mpctl, perfd)

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,11 +1,5 @@
 /data/cam_socket.*                                 u:object_r:camera_socket:s0
 
-/sys/devices/virtual/graphics/fb0/aco              u:object_r:display_sysfs:s0
-/sys/devices/virtual/graphics/fb0/cabc             u:object_r:display_sysfs:s0
-/sys/devices/virtual/graphics/fb0/color_enhance    u:object_r:display_sysfs:s0
-/sys/devices/virtual/graphics/fb0/sre              u:object_r:display_sysfs:s0
-/sys/devices/virtual/graphics/fb0/rgb              u:object_r:display_sysfs:s0
-
 /sys/devices/virtual/timed_output/vibrator/vtg_level   u:object_r:vibeamp_sysfs:s0
 
 /persist/.genmac                                u:object_r:wifi_data_file:s0


### PR DESCRIPTION
Since some of the common policies were moved to vendor/cm, remove
them from the device-specific policies.

HAM-1198

Change-Id: Ia8b8f0df904d9d44349f94a0951e3454ef3c29bf
